### PR TITLE
Add upgrade handler for "jip-2" and handle store upgrades

### DIFF
--- a/app/upgrade.go
+++ b/app/upgrade.go
@@ -2,6 +2,8 @@ package app
 
 import (
 	"context"
+	storetypes "cosmossdk.io/store/types"
+	trackgatemoduletypes "github.com/airchains-network/junction/x/trackgate/types"
 
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
@@ -11,12 +13,16 @@ import (
 func CreateDefaultUpgradeHandler(
 	mm *module.Manager,
 	configurator module.Configurator,
+	app *App,
 ) upgradetypes.UpgradeHandler {
 	return func(ctx context.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-		versionMap := module.VersionMap{
-			"junction": 100, // version 1.0.0
+		storeUpgrades := storetypes.StoreUpgrades{
+			Added: []string{trackgatemoduletypes.StoreKey},
 		}
 
-		return versionMap, nil
+		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(plan.Height, &storeUpgrades))
+
+		//return versionMap, nil
+		return app.ModuleManager.RunMigrations(ctx, configurator, fromVM)
 	}
 }


### PR DESCRIPTION
Introduced a new upgrade handler for "jip-2" with store upgrade functionalities. The handler now sets the store loader with the appropriate store upgrades and runs module migrations. Updated the app initialization to handle the new upgrade conditions.