### PR TITLE
Refactor byte conversion for station ID

### DIFF
--- a/x/trackgate/keeper/msg_server_init_station.go
+++ b/x/trackgate/keeper/msg_server_init_station.go
@@ -63,7 +63,8 @@ func (k msgServer) InitStation(goCtx context.Context, msg *types.MsgInitStation)
 	}
 
 	extTrackStationsDataDB := prefix.NewStore(storeAdapter, types.KeyPrefix(types.ExtTrackStationsDataStoreKey))
-	uniqueStationIDCheck := extTrackStationsDataDB.Get([]byte(stationId))
+	stationIdBytes := []byte(stationId)
+	uniqueStationIDCheck := extTrackStationsDataDB.Get(stationIdBytes)
 	if uniqueStationIDCheck != nil {
 		return &types.MsgInitStationResponse{
 			Status: false,

--- a/x/trackgate/keeper/msg_server_schema_creation.go
+++ b/x/trackgate/keeper/msg_server_schema_creation.go
@@ -38,7 +38,8 @@ func (k msgServer) SchemaCreation(goCtx context.Context, msg *types.MsgSchemaCre
 	}
 
 	extTrackStationsDataDB := prefix.NewStore(storeAdapter, types.KeyPrefix(types.ExtTrackStationsDataStoreKey))
-	stationDataByte := extTrackStationsDataDB.Get([]byte(extTrackStationId))
+	extTrackStationIdByte := []byte(extTrackStationId)
+	stationDataByte := extTrackStationsDataDB.Get(extTrackStationIdByte)
 	if stationDataByte == nil {
 		return &types.MsgSchemaCreationResponse{
 			SchemaKey: "",


### PR DESCRIPTION
Refactor how station IDs are converted to byte slices before database operations to enhance clarity and consistency. This change impacts `msg_server_schema_creation.go` and `msg_server_init_station.go`, ensuring all station ID bytes are handled uniformly.